### PR TITLE
v0.5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mdq (0.5.1)
+    mdq (0.5.2)
       activerecord
       sqlite3
       thor

--- a/README.base.md
+++ b/README.base.md
@@ -47,7 +47,10 @@ $ mdq list
     "capacity": 16,
     "human_readable_total_disk": "109.91 GB",
     "human_readable_used_disk": "17.96 GB",
-    "human_readable_available_disk": "91.95 GB"
+    "human_readable_available_disk": "91.95 GB",
+    "mac_address": null,
+    "ip_address": null,
+    "ipv6_address": null
   },
   {
     "id": 2,
@@ -67,7 +70,11 @@ $ mdq list
     "capacity": null,
     "human_readable_total_disk": "128.0 GB",
     "human_readable_used_disk": null,
-    "human_readable_available_disk": null
+    "human_readable_available_disk": null,
+    "mac_address": null,
+    "ip_address": null,
+    "ipv6_address": null
+
   }
 ]
 ```
@@ -95,7 +102,10 @@ $ mdq list -q="select * from devices where platform='iOS'"
     "capacity": null,
     "human_readable_total_disk": "128.0 GB",
     "human_readable_used_disk": null,
-    "human_readable_available_disk": null
+    "human_readable_available_disk": null,
+    "mac_address": null,
+    "ip_address": null,
+    "ipv6_address": null
   }
 ]
 ```
@@ -151,6 +161,10 @@ Details of the devices table.
 | human_readable_total_disk | total_disk | total_disk |
 | human_readable_available_disk | available_disk | Always "null" |
 | human_readable_used_disk | used_disk | Always "null" |
+| mac_address | MAC address (may be a random MAC address) | Always "null" |
+| ip_address | IPv4 Address | Always "null" |
+| ipv6_address | IPv6 Address |  Always "null" |
+
 
 Details of the apps table.
 Apple Devices displays the apps installed with Xcode.

--- a/README.base.md
+++ b/README.base.md
@@ -45,9 +45,9 @@ $ mdq list
     "used_disk": 18835692000,
     "available_disk": 96413544000,
     "capacity": 16,
-    "human_readable_total_disk": "107.33 GB",
-    "human_readable_used_disk": "17.54 GB",
-    "human_readable_available_disk": "89.79 GB"
+    "human_readable_total_disk": "115.25 GB",
+    "human_readable_used_disk": "18.84 GB",
+    "human_readable_available_disk": "96.41 GB"
   },
   {
     "id": 2,
@@ -65,7 +65,7 @@ $ mdq list
     "used_disk": null,
     "available_disk": null,
     "capacity": null,
-    "human_readable_total_disk": "119.21 GB",
+    "human_readable_total_disk": "128.0 GB",
     "human_readable_used_disk": null,
     "human_readable_available_disk": null
   }
@@ -93,7 +93,7 @@ $ mdq list -q="select * from devices where platform='iOS'"
     "used_disk": null,
     "available_disk": null,
     "capacity": null,
-    "human_readable_total_disk": "119.21 GB",
+    "human_readable_total_disk": "128.0 GB",
     "human_readable_used_disk": null,
     "human_readable_available_disk": null
   }

--- a/README.base.md
+++ b/README.base.md
@@ -41,13 +41,13 @@ $ mdq list
     "build_version": "16",
     "build_id": "BP31.250502.008",
     "battery_level": 88,
-    "total_disk": 115249236000,
-    "used_disk": 18835692000,
-    "available_disk": 96413544000,
+    "total_disk": 118015217664,
+    "used_disk": 19287748608,
+    "available_disk": 98727469056,
     "capacity": 16,
-    "human_readable_total_disk": "115.25 GB",
-    "human_readable_used_disk": "18.84 GB",
-    "human_readable_available_disk": "96.41 GB"
+    "human_readable_total_disk": "109.91 GB",
+    "human_readable_used_disk": "17.96 GB",
+    "human_readable_available_disk": "91.95 GB"
   },
   {
     "id": 2,

--- a/README.base.md
+++ b/README.base.md
@@ -48,9 +48,10 @@ $ mdq list
     "human_readable_total_disk": "109.91 GB",
     "human_readable_used_disk": "17.96 GB",
     "human_readable_available_disk": "91.95 GB",
-    "mac_address": null,
-    "ip_address": null,
-    "ipv6_address": null
+    "mac_address": "ff:ff:ff:ff:ff:ff",
+    "ip_address": "192.168.1.1",
+    "ipv6_address": "IPV6_1,IPV6_2,IPV6_3,IPV6_3",
+    "wifi_network": "MyNet"
   },
   {
     "id": 2,
@@ -73,8 +74,8 @@ $ mdq list
     "human_readable_available_disk": null,
     "mac_address": null,
     "ip_address": null,
-    "ipv6_address": null
-
+    "ipv6_address": null,
+    "wifi_network": null
   }
 ]
 ```
@@ -105,7 +106,8 @@ $ mdq list -q="select * from devices where platform='iOS'"
     "human_readable_available_disk": null,
     "mac_address": null,
     "ip_address": null,
-    "ipv6_address": null
+    "ipv6_address": null,
+    "wifi_network": null
   }
 ]
 ```
@@ -163,9 +165,9 @@ Details of the devices table.
 | human_readable_used_disk | used_disk | Always "null" |
 | mac_address | MAC address (may be a random MAC address) | Always "null" |
 | ip_address | IPv4 Address | Always "null" |
-| ipv6_address | IPv6 Address |  Always "null" |
-
-
+| ipv6_address | IPv6 Address | Always "null" |
+| wifi_network | Wi-Fi Network | Always "null" |
+ 
 Details of the apps table.
 Apple Devices displays the apps installed with Xcode.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -40,9 +40,9 @@ $ mdq list
     "used_disk": 18835692000,
     "available_disk": 96413544000,
     "capacity": 16,
-    "human_readable_total_disk": "107.33 GB",
-    "human_readable_used_disk": "17.54 GB",
-    "human_readable_available_disk": "89.79 GB"
+    "human_readable_total_disk": "115.25 GB",
+    "human_readable_used_disk": "18.84 GB",
+    "human_readable_available_disk": "96.41 GB"
   },
   {
     "id": 2,
@@ -60,7 +60,7 @@ $ mdq list
     "used_disk": null,
     "available_disk": null,
     "capacity": null,
-    "human_readable_total_disk": "119.21 GB",
+    "human_readable_total_disk": "128.0 GB",
     "human_readable_used_disk": null,
     "human_readable_available_disk": null
   }
@@ -88,7 +88,7 @@ $ mdq list -q="select * from devices where platform='iOS'"
     "used_disk": null,
     "available_disk": null,
     "capacity": null,
-    "human_readable_total_disk": "119.21 GB",
+    "human_readable_total_disk": "128.0 GB",
     "human_readable_used_disk": null,
     "human_readable_available_disk": null
   }

--- a/README.ja.md
+++ b/README.ja.md
@@ -43,9 +43,10 @@ $ mdq list
     "human_readable_total_disk": "109.91 GB",
     "human_readable_used_disk": "17.96 GB",
     "human_readable_available_disk": "91.95 GB",
-    "mac_address": null,
-    "ip_address": null,
-    "ipv6_address": null
+    "mac_address": "ff:ff:ff:ff:ff:ff",
+    "ip_address": "192.168.1.1",
+    "ipv6_address": "IPV6_1,IPV6_2,IPV6_3,IPV6_3",
+    "wifi_network": "MyNet"
   },
   {
     "id": 2,
@@ -68,8 +69,8 @@ $ mdq list
     "human_readable_available_disk": null,
     "mac_address": null,
     "ip_address": null,
-    "ipv6_address": null
-
+    "ipv6_address": null,
+    "wifi_network": null
   }
 ]
 ```
@@ -100,7 +101,8 @@ $ mdq list -q="select * from devices where platform='iOS'"
     "human_readable_available_disk": null,
     "mac_address": null,
     "ip_address": null,
-    "ipv6_address": null
+    "ipv6_address": null,
+    "wifi_network": null
   }
 ]
 ```
@@ -158,9 +160,9 @@ Details of the devices table.
 | human_readable_used_disk | used_disk | Always "null" |
 | mac_address | MAC address (may be a random MAC address) | Always "null" |
 | ip_address | IPv4 Address | Always "null" |
-| ipv6_address | IPv6 Address |  Always "null" |
-
-
+| ipv6_address | IPv6 Address | Always "null" |
+| wifi_network | Wi-Fi Network | Always "null" |
+ 
 Details of the apps table.
 Apple Devices displays the apps installed with Xcode.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -42,7 +42,10 @@ $ mdq list
     "capacity": 16,
     "human_readable_total_disk": "109.91 GB",
     "human_readable_used_disk": "17.96 GB",
-    "human_readable_available_disk": "91.95 GB"
+    "human_readable_available_disk": "91.95 GB",
+    "mac_address": null,
+    "ip_address": null,
+    "ipv6_address": null
   },
   {
     "id": 2,
@@ -62,7 +65,11 @@ $ mdq list
     "capacity": null,
     "human_readable_total_disk": "128.0 GB",
     "human_readable_used_disk": null,
-    "human_readable_available_disk": null
+    "human_readable_available_disk": null,
+    "mac_address": null,
+    "ip_address": null,
+    "ipv6_address": null
+
   }
 ]
 ```
@@ -90,7 +97,10 @@ $ mdq list -q="select * from devices where platform='iOS'"
     "capacity": null,
     "human_readable_total_disk": "128.0 GB",
     "human_readable_used_disk": null,
-    "human_readable_available_disk": null
+    "human_readable_available_disk": null,
+    "mac_address": null,
+    "ip_address": null,
+    "ipv6_address": null
   }
 ]
 ```
@@ -146,6 +156,10 @@ Details of the devices table.
 | human_readable_total_disk | total_disk | total_disk |
 | human_readable_available_disk | available_disk | Always "null" |
 | human_readable_used_disk | used_disk | Always "null" |
+| mac_address | MAC address (may be a random MAC address) | Always "null" |
+| ip_address | IPv4 Address | Always "null" |
+| ipv6_address | IPv6 Address |  Always "null" |
+
 
 Details of the apps table.
 Apple Devices displays the apps installed with Xcode.

--- a/README.ja.md
+++ b/README.ja.md
@@ -36,13 +36,13 @@ $ mdq list
     "build_version": "16",
     "build_id": "BP31.250502.008",
     "battery_level": 88,
-    "total_disk": 115249236000,
-    "used_disk": 18835692000,
-    "available_disk": 96413544000,
+    "total_disk": 118015217664,
+    "used_disk": 19287748608,
+    "available_disk": 98727469056,
     "capacity": 16,
-    "human_readable_total_disk": "115.25 GB",
-    "human_readable_used_disk": "18.84 GB",
-    "human_readable_available_disk": "96.41 GB"
+    "human_readable_total_disk": "109.91 GB",
+    "human_readable_used_disk": "17.96 GB",
+    "human_readable_available_disk": "91.95 GB"
   },
   {
     "id": 2,

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ $ mdq list
     "used_disk": 18835692000,
     "available_disk": 96413544000,
     "capacity": 16,
-    "human_readable_total_disk": "107.33 GB",
-    "human_readable_used_disk": "17.54 GB",
-    "human_readable_available_disk": "89.79 GB"
+    "human_readable_total_disk": "115.25 GB",
+    "human_readable_used_disk": "18.84 GB",
+    "human_readable_available_disk": "96.41 GB"
   },
   {
     "id": 2,
@@ -60,7 +60,7 @@ $ mdq list
     "used_disk": null,
     "available_disk": null,
     "capacity": null,
-    "human_readable_total_disk": "119.21 GB",
+    "human_readable_total_disk": "128.0 GB",
     "human_readable_used_disk": null,
     "human_readable_available_disk": null
   }
@@ -88,7 +88,7 @@ $ mdq list -q="select * from devices where platform='iOS'"
     "used_disk": null,
     "available_disk": null,
     "capacity": null,
-    "human_readable_total_disk": "119.21 GB",
+    "human_readable_total_disk": "128.0 GB",
     "human_readable_used_disk": null,
     "human_readable_available_disk": null
   }

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ $ mdq list
     "human_readable_total_disk": "109.91 GB",
     "human_readable_used_disk": "17.96 GB",
     "human_readable_available_disk": "91.95 GB",
-    "mac_address": null,
-    "ip_address": null,
-    "ipv6_address": null
+    "mac_address": "ff:ff:ff:ff:ff:ff",
+    "ip_address": "192.168.1.1",
+    "ipv6_address": "IPV6_1,IPV6_2,IPV6_3,IPV6_3",
+    "wifi_network": "MyNet"
   },
   {
     "id": 2,
@@ -68,8 +69,8 @@ $ mdq list
     "human_readable_available_disk": null,
     "mac_address": null,
     "ip_address": null,
-    "ipv6_address": null
-
+    "ipv6_address": null,
+    "wifi_network": null
   }
 ]
 ```
@@ -100,7 +101,8 @@ $ mdq list -q="select * from devices where platform='iOS'"
     "human_readable_available_disk": null,
     "mac_address": null,
     "ip_address": null,
-    "ipv6_address": null
+    "ipv6_address": null,
+    "wifi_network": null
   }
 ]
 ```
@@ -158,9 +160,9 @@ Details of the devices table.
 | human_readable_used_disk | used_disk | Always "null" |
 | mac_address | MAC address (may be a random MAC address) | Always "null" |
 | ip_address | IPv4 Address | Always "null" |
-| ipv6_address | IPv6 Address |  Always "null" |
-
-
+| ipv6_address | IPv6 Address | Always "null" |
+| wifi_network | Wi-Fi Network | Always "null" |
+ 
 Details of the apps table.
 Apple Devices displays the apps installed with Xcode.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ $ mdq list
     "capacity": 16,
     "human_readable_total_disk": "109.91 GB",
     "human_readable_used_disk": "17.96 GB",
-    "human_readable_available_disk": "91.95 GB"
+    "human_readable_available_disk": "91.95 GB",
+    "mac_address": null,
+    "ip_address": null,
+    "ipv6_address": null
   },
   {
     "id": 2,
@@ -62,7 +65,11 @@ $ mdq list
     "capacity": null,
     "human_readable_total_disk": "128.0 GB",
     "human_readable_used_disk": null,
-    "human_readable_available_disk": null
+    "human_readable_available_disk": null,
+    "mac_address": null,
+    "ip_address": null,
+    "ipv6_address": null
+
   }
 ]
 ```
@@ -90,7 +97,10 @@ $ mdq list -q="select * from devices where platform='iOS'"
     "capacity": null,
     "human_readable_total_disk": "128.0 GB",
     "human_readable_used_disk": null,
-    "human_readable_available_disk": null
+    "human_readable_available_disk": null,
+    "mac_address": null,
+    "ip_address": null,
+    "ipv6_address": null
   }
 ]
 ```
@@ -146,6 +156,10 @@ Details of the devices table.
 | human_readable_total_disk | total_disk | total_disk |
 | human_readable_available_disk | available_disk | Always "null" |
 | human_readable_used_disk | used_disk | Always "null" |
+| mac_address | MAC address (may be a random MAC address) | Always "null" |
+| ip_address | IPv4 Address | Always "null" |
+| ipv6_address | IPv6 Address |  Always "null" |
+
 
 Details of the apps table.
 Apple Devices displays the apps installed with Xcode.

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ $ mdq list
     "build_version": "16",
     "build_id": "BP31.250502.008",
     "battery_level": 88,
-    "total_disk": 115249236000,
-    "used_disk": 18835692000,
-    "available_disk": 96413544000,
+    "total_disk": 118015217664,
+    "used_disk": 19287748608,
+    "available_disk": 98727469056,
     "capacity": 16,
-    "human_readable_total_disk": "115.25 GB",
-    "human_readable_used_disk": "18.84 GB",
-    "human_readable_available_disk": "96.41 GB"
+    "human_readable_total_disk": "109.91 GB",
+    "human_readable_used_disk": "17.96 GB",
+    "human_readable_available_disk": "91.95 GB"
   },
   {
     "id": 2,

--- a/lib/mdq/discovery.rb
+++ b/lib/mdq/discovery.rb
@@ -196,6 +196,7 @@ module Mdq
       ActiveRecord::Base.connection.execute("delete from sqlite_sequence where name='apps'")
     end
 
+    # バイト単位の数値を変換
     def number_to_human_size(size)
       return nil if size.nil?
 

--- a/lib/mdq/discovery.rb
+++ b/lib/mdq/discovery.rb
@@ -200,7 +200,7 @@ module Mdq
     end
 
     # バイト単位の数値を変換
-    def number_to_human_size(size, k)
+    def number_to_human_size(size, k) # rubocop:disable Naming/MethodParameterName
       return nil if size.nil?
 
       units = [' B', ' KB', ' MB', ' GB', ' TB']

--- a/lib/mdq/version.rb
+++ b/lib/mdq/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mdq
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/spec/db_spec.rb
+++ b/spec/db_spec.rb
@@ -80,13 +80,13 @@ RSpec.describe Mdq::DB do # rubocop:disable Metrics/BlockLength
       "build_version": '16',
       "build_id": 'BP31.250502.008',
       "battery_level": 88,
-      "total_disk": 115_249_236_000,
-      "used_disk": 18_835_692_000,
-      "available_disk": 96_413_544_000,
+      "total_disk": 118_015_217_664,
+      "used_disk": 19_287_748_608,
+      "available_disk": 98_727_469_056,
       "capacity": 16,
-      "human_readable_total_disk": '115.25 GB',
-      "human_readable_used_disk": '18.84 GB',
-      "human_readable_available_disk": '96.41 GB'
+      "human_readable_total_disk": '109.91 GB',
+      "human_readable_used_disk": '17.96 GB',
+      "human_readable_available_disk": '91.95 GB'
     }, {
       "id": 2,
       "udid": 'APPLE_UDID',

--- a/spec/db_spec.rb
+++ b/spec/db_spec.rb
@@ -49,19 +49,26 @@ RSpec.describe Mdq::DB do # rubocop:disable Metrics/BlockLength
     )
 
     allow(db).to receive(:adb_command).with('shell ip addr show wlan0', 'ANDROID_UDID').and_return(
-      ['47: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000'],
-      ['link/ether ff:ff:ff:ff:ff:ff brd ff:ff:ff:ff:ff:ff'],
-      ['inet 192.168.1.1/24 brd 192.168.1.255 scope global wlan0'],
-      ['   valid_lft forever preferred_lft forever'],
-      ['inet6 IPV6_1/64 scope global temporary dynamic'],
-      ['   valid_lft 86356sec preferred_lft 71618sec'],
-      ['inet6 IPV6_2/64 scope global temporary deprecated dynamic'],
-      ['   valid_lft 86356sec preferred_lft 0sec'],
-      ['inet6 IPV6_3/64 scope global dynamic mngtmpaddr'],
-      ['   valid_lft 86356sec preferred_lft 86356sec'],
-      ['inet6 IPV6_3/64 scope link'],
-      ['   valid_lft forever preferred_lft forever'].join("\n")
+      ['47: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000',
+       'link/ether ff:ff:ff:ff:ff:ff brd ff:ff:ff:ff:ff:ff',
+       'inet 192.168.1.1/24 brd 192.168.1.255 scope global wlan0',
+       '   valid_lft forever preferred_lft forever',
+       'inet6 IPV6_1/64 scope global temporary dynamic',
+       '   valid_lft 86356sec preferred_lft 71618sec',
+       'inet6 IPV6_2/64 scope global temporary deprecated dynamic',
+       '   valid_lft 86356sec preferred_lft 0sec',
+       'inet6 IPV6_3/64 scope global dynamic mngtmpaddr',
+       '   valid_lft 86356sec preferred_lft 86356sec',
+       'inet6 IPV6_3/64 scope link',
+       '   valid_lft forever preferred_lft forever'].join("\n")
     )
+
+    allow(db).to receive(:adb_command).with("shell dumpsys netstats | grep -E 'iface=wlan0'",
+                                            'ANDROID_UDID').and_return(
+                                              ['iface=wlan0 ident=[{type=1, ratType=COMBINED, wifiNetworkKey="MyNet"wpa2-psk, metered=false, defaultNetwork=true, oemManaged=OEM_NONE, subId=-1}]', # rubocop:disable Layout/LineLength
+                                               'iface=wlan0 ident=[{type=1, ratType=COMBINED, wifiNetworkKey="MyNet"wpa2-psk, metered=false, defaultNetwork=true, oemManaged=OEM_NONE, subId=-1}]'] # rubocop:disable Layout/LineLength
+                                                                                        .join("\n")
+                                            )
 
     # Apple Devices
     allow(db).to receive(:apple_command).with("list devices -v -j #{file}").and_return(nil)
@@ -102,9 +109,10 @@ RSpec.describe Mdq::DB do # rubocop:disable Metrics/BlockLength
       "human_readable_total_disk": '109.91 GB',
       "human_readable_used_disk": '17.96 GB',
       "human_readable_available_disk": '91.95 GB',
-      "mac_address": nil,
-      "ip_address": nil,
-      "ipv6_address": ''
+      "mac_address": 'ff:ff:ff:ff:ff:ff',
+      "ip_address": '192.168.1.1',
+      "ipv6_address": 'IPV6_1,IPV6_2,IPV6_3,IPV6_3',
+      "wifi_network": 'MyNet'
     }, {
       "id": 2,
       "udid": 'APPLE_UDID',
@@ -126,7 +134,8 @@ RSpec.describe Mdq::DB do # rubocop:disable Metrics/BlockLength
       "human_readable_available_disk": nil,
       "mac_address": nil,
       "ip_address": nil,
-      "ipv6_address": nil
+      "ipv6_address": nil,
+      "wifi_network": nil
 
     }].to_json
 

--- a/spec/db_spec.rb
+++ b/spec/db_spec.rb
@@ -48,6 +48,21 @@ RSpec.describe Mdq::DB do # rubocop:disable Metrics/BlockLength
       ['package:com.example.android1', 'package:com.example.android2'].join("\n")
     )
 
+    allow(db).to receive(:adb_command).with('shell ip addr show wlan0', 'ANDROID_UDID').and_return(
+      ['47: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000'],
+      ['link/ether ff:ff:ff:ff:ff:ff brd ff:ff:ff:ff:ff:ff'],
+      ['inet 192.168.1.1/24 brd 192.168.1.255 scope global wlan0'],
+      ['   valid_lft forever preferred_lft forever'],
+      ['inet6 IPV6_1/64 scope global temporary dynamic'],
+      ['   valid_lft 86356sec preferred_lft 71618sec'],
+      ['inet6 IPV6_2/64 scope global temporary deprecated dynamic'],
+      ['   valid_lft 86356sec preferred_lft 0sec'],
+      ['inet6 IPV6_3/64 scope global dynamic mngtmpaddr'],
+      ['   valid_lft 86356sec preferred_lft 86356sec'],
+      ['inet6 IPV6_3/64 scope link'],
+      ['   valid_lft forever preferred_lft forever'].join("\n")
+    )
+
     # Apple Devices
     allow(db).to receive(:apple_command).with("list devices -v -j #{file}").and_return(nil)
     allow(db).to receive(:apple_command).with('--version').and_return(443.19)
@@ -86,7 +101,10 @@ RSpec.describe Mdq::DB do # rubocop:disable Metrics/BlockLength
       "capacity": 16,
       "human_readable_total_disk": '109.91 GB',
       "human_readable_used_disk": '17.96 GB',
-      "human_readable_available_disk": '91.95 GB'
+      "human_readable_available_disk": '91.95 GB',
+      "mac_address": nil,
+      "ip_address": nil,
+      "ipv6_address": ''
     }, {
       "id": 2,
       "udid": 'APPLE_UDID',
@@ -105,7 +123,11 @@ RSpec.describe Mdq::DB do # rubocop:disable Metrics/BlockLength
       "capacity": nil,
       "human_readable_total_disk": '128.0 GB',
       "human_readable_used_disk": nil,
-      "human_readable_available_disk": nil
+      "human_readable_available_disk": nil,
+      "mac_address": nil,
+      "ip_address": nil,
+      "ipv6_address": nil
+
     }].to_json
 
     expect(devices.to_json).to eq test_devices

--- a/spec/discovery_spec.rb
+++ b/spec/discovery_spec.rb
@@ -6,11 +6,21 @@ require 'mdq/discovery'
 RSpec.describe Mdq::Discovery do
   let(:discovery) { Mdq::Discovery.new }
 
-  it 'discovery' do
-    expect(discovery.send(:number_to_human_size, 1)).to eq '1.0 B'
-    expect(discovery.send(:number_to_human_size, 1000)).to eq '1000.0 B'
-    expect(discovery.send(:number_to_human_size, 1001)).to eq '1.0 KB'
-    expect(discovery.send(:number_to_human_size, 123_456_789)).to eq '123.46 MB'
-    expect(discovery.send(:number_to_human_size, 128_000_000_000)).to eq '128.0 GB'
+  it 'discovery k1000' do
+    k = 1000.0
+    expect(discovery.send(:number_to_human_size, 1, k)).to eq '1.0 B'
+    expect(discovery.send(:number_to_human_size, 1000, k)).to eq '1000.0 B'
+    expect(discovery.send(:number_to_human_size, 1001, k)).to eq '1.0 KB'
+    expect(discovery.send(:number_to_human_size, 123_456_789, k)).to eq '123.46 MB'
+    expect(discovery.send(:number_to_human_size, 128_000_000_000, k)).to eq '128.0 GB'
+  end
+
+  it 'discovery k1024' do
+    k = 1024.0
+    expect(discovery.send(:number_to_human_size, 1, k)).to eq '1.0 B'
+    expect(discovery.send(:number_to_human_size, 1000, k)).to eq '1000.0 B'
+    expect(discovery.send(:number_to_human_size, 1001, k)).to eq '1001.0 B'
+    expect(discovery.send(:number_to_human_size, 123_456_789, k)).to eq '117.74 MB'
+    expect(discovery.send(:number_to_human_size, 128_000_000_000, k)).to eq '119.21 GB'
   end
 end

--- a/spec/discovery_spec.rb
+++ b/spec/discovery_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe Mdq::Discovery do
   let(:discovery) { Mdq::Discovery.new }
 
   it 'discovery' do
+    expect(discovery.send(:number_to_human_size, 1)).to eq '1.0 B'
+    expect(discovery.send(:number_to_human_size, 1000)).to eq '1000.0 B'
+    expect(discovery.send(:number_to_human_size, 1001)).to eq '1.0 KB'
+    expect(discovery.send(:number_to_human_size, 123_456_789)).to eq '123.46 MB'
     expect(discovery.send(:number_to_human_size, 128_000_000_000)).to eq '128.0 GB'
   end
 end


### PR DESCRIPTION
Androidのディスク容量の計算方法を修正しました。
AndroidのMACアドレス（ランダムMACアドレスの場合あり）、IPアドレス、IPv6アドレス、Wi-Fiの名前の取得機能を追加しました。